### PR TITLE
Add new function Purge-CFFile.ps1 with docs, and an example

### DIFF
--- a/docs/Functions/Purge-CFFile.md
+++ b/docs/Functions/Purge-CFFile.md
@@ -1,0 +1,149 @@
+﻿---
+external help file: PSCloudFlare-help.xml
+Module Name: PSCloudFlare
+online version: https://github.com/zloeber/PSCloudFlare
+schema: 2.0.0
+---
+
+# Purge-CFFile
+
+## SYNOPSIS
+Purge Files by URL, Cache-Tags or Host
+
+## SYNTAX
+
+### Everything
+```
+Purge-CFFile [-ZoneID <String>] [-Everything] [<CommonParameters>]
+```
+
+### SingleURL
+```
+Purge-CFFile [-ZoneID <String>] [-Url <String>] [<CommonParameters>]
+```
+
+### MultipleURLs
+```
+Purge-CFFile [-ZoneID <String>] [-Urls <Array>] [<CommonParameters>]
+```
+
+### CacheTagsOrHosts
+```
+Purge-CFFile [-ZoneID <String>] [-CacheTags <Array>] [-Hosts <Array>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Purge Files by URL, Cache-Tags or Host
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Purge-CFFile -Urls $StaleUrls
+```
+
+## PARAMETERS
+
+### -ZoneID
+ZoneID.
+If you pass ZoneID it will be targeted otherwise the currently loaded zone from Set-CFCurrentZone is targeted.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Everything
+Purge everything
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Everything
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Url
+Purge a single URL
+
+```yaml
+Type: String
+Parameter Sets: SingleURL
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Urls
+Purge multiple URLs
+
+```yaml
+Type: Array
+Parameter Sets: MultipleURLs
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CacheTags
+Purge by cache tags
+
+```yaml
+Type: Array
+Parameter Sets: CacheTagsOrHosts
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Hosts
+Purge by hosts
+
+```yaml
+Type: Array
+Parameter Sets: CacheTagsOrHosts
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+Author: Leo
+
+## RELATED LINKS

--- a/examples/example6.ps1
+++ b/examples/example6.ps1
@@ -1,0 +1,23 @@
+Import-Module PSCloudFlare
+$Token = '<your API token>'
+$Email = 'itops@contoso.com'
+$Zone = 'contoso.com'
+
+# Connect to the CloudFlare Client API
+try {
+    Connect-CFClientAPI -APIToken $Token -EmailAddress $Email -ErrorAction Stop
+}
+catch {
+    throw $_
+}
+
+# Retrieve all records in the zone
+Set-CFCurrentZone -Zone $Zone -Verbose
+
+# Purge stale URLs
+$URLs = @(
+    "https://contoso.com/stale/link/01"
+    "https://contoso.com/stale/link/02"
+    "https://contoso.com/stale/link/03"
+)
+Purge-CFFile -Urls $URLs

--- a/src/public/Purge-CFFile.ps1
+++ b/src/public/Purge-CFFile.ps1
@@ -1,0 +1,116 @@
+# Purge Files by URL, Cache-Tags or Host
+function Purge-CFFile {
+    <#
+    .SYNOPSIS
+    Purge Files by URL, Cache-Tags or Host
+    .DESCRIPTION
+    Purge Files by URL, Cache-Tags or Host
+    .PARAMETER ZoneID
+    ZoneID. If you pass ZoneID it will be targeted otherwise the currently loaded zone from Set-CFCurrentZone is targeted.
+    .PARAMETER Everything
+    Purge everything
+    .PARAMETER Url
+    Purge a single URL
+    .PARAMETER Urls
+    Purge multiple URLs
+    .PARAMETER CacheTags
+    Purge by cache tags
+    .PARAMETER Hosts
+    Purge by hosts
+    .EXAMPLE
+    Purge-CFFile -Urls $StaleUrls
+    .NOTES
+    Author: Leo
+    #>
+    [CmdletBinding()]
+    Param (
+        [Parameter()]
+        [ValidateScript({ IsNullOrCFID $_ })]
+        [String]$ZoneID
+    ,
+        [Parameter(ParameterSetName='Everything')]
+        [ValidateNotNullOrEmpty()]
+        [switch]$Everything
+    ,
+        [Parameter(ParameterSetName='SingleURL')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url
+    ,
+        [Parameter(ParameterSetName='MultipleURLs')]
+        [ValidateNotNullOrEmpty()]
+        [array]$Urls
+    ,
+        [Parameter(ParameterSetName='CacheTagsOrHosts')]
+        [ValidateNotNullOrEmpty()]
+        [array]$CacheTags
+        ,
+        [Parameter(ParameterSetName='CacheTagsOrHosts')]
+        [ValidateNotNullOrEmpty()]
+        [array]$Hosts
+    )
+    begin {
+        if ($script:ThisModuleLoaded -eq $true) {
+            Get-CallerPreference -Cmdlet $PSCmdlet -SessionState $ExecutionContext.SessionState
+        }
+        $FunctionName = $MyInvocation.MyCommand.Name
+        Write-Verbose "$($FunctionName): Begin."
+
+        # If the ZoneID is empty see if we have loaded one earlier in the module and use it instead.
+        if ([string]::IsNullOrEmpty($ZoneID) -and ($Script:ZoneID -ne $null)) {
+            Write-Verbose "$($FunctionName): No ZoneID was passed but the current targeted zone was $($Script:ZoneName) so this will be used."
+            $ZoneID = $Script:ZoneID
+        }
+        elseif ([string]::IsNullOrEmpty($ZoneID)) {
+            throw 'No Zone was set or passed!'
+        }
+    }
+    end {
+        # Construct the URI for this package
+        $Uri = $Script:APIURI + ('/zones/{0}/purge_cache' -f $ZoneID)
+        Write-Verbose "$($FunctionName): URI = '$Uri'"
+
+        # Prepare the body
+        switch ($PSCmdlet.ParameterSetName) {
+            'Everything' {
+                $Data = @{
+                    purge_everything = $true
+                }
+                break
+            }
+            'SingleURL' {
+                # Wrap a single URL in an array
+                $Data = @{
+                    files = @( $Url )
+                }
+                break
+            }
+            'MultipleURLs' {
+                $Data = @{
+                    files = $Urls
+                }
+                break
+            }
+            'CacheTagsOrHosts' {
+                $Data = @{}
+                if ($CacheTags) {
+                    $Data['tags'] = $CacheTags
+                }
+                if ($Hosts) {
+                    $Data['hosts'] = $Hosts
+                }
+                break
+            }
+            default {}
+        }
+
+        try {
+            Set-CFRequestData -Uri $Uri -Body $Data -Method 'Post'
+            $Response = Invoke-CFAPI4Request -ErrorAction Stop
+        }
+        catch {
+            Throw $_
+        }
+
+        Write-Verbose "$($FunctionName): End."
+    }
+}


### PR DESCRIPTION
# Scope
Add new function Purge-CFFile.ps1 with docs, and  an example

# Limitations
The function name starts with `Purge` and hence does not comply to the naming conventions of Powershell. The only alternative is `Remove-CFFile` which isn't very intuitive. Or perhaps there are better nouns than CFFile. Either way, if you insist on following conventions, or have a better suggestion, I could rename the function.

# Examples
```powershell
# Purge everything
Purge-CFFile -Everything

# Purge single file
Purge-CFFile -Url 'https://contoso.com/some/stale/link' 

# Purge multiple files
Purge-CFFile -Urls @(
    "https://contoso.com/stale/link/01"
    "https://contoso.com/stale/link/02"
    "https://contoso.com/stale/link/03"
)

# Purge by both Cache tags and / or Hosts
Purge-CFFile -CacheTags 'foo', 'bar' -Hosts 'contoso.com', 'images.contoso.com'
```

# Tests
Tested the `-Everything`, `-Url`, and `-Urls` parameters which worked without issues.
However, since the `-CacheTags` or `-Hosts`  parameters are only for Enterprise customers, I could only see the function throw an error about it being only allowed for enterprise customers. 
